### PR TITLE
Stop the old notifier on Reload

### DIFF
--- a/react.py
+++ b/react.py
@@ -65,6 +65,7 @@ while True:
             if notifier.check_events():
                 notifier.read_events()
     except Reload:
+        notifier.stop()
         pass
     except KeyboardInterrupt:
         notifier.stop()


### PR DESCRIPTION
This fixes react from leaking inotify file descriptors (instances and
its watches), which leads to (global) "No space left on device (ENOSPC)"
errors in the long run.

The issue in pyinotify (fixing garbage collection) is (fixed with): https://github.com/seb-m/pyinotify/pull/96
